### PR TITLE
Update analyze.py

### DIFF
--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -11,6 +11,7 @@ class Options:
    search_time = 60
    cores = 1
    hash_size = 4000
+   syzygy = '/syzygypath'
 
 class Results:
    # the current position's results indexed by multipv index
@@ -33,6 +34,7 @@ position = Position()
 done = False
 
 solved = 0
+tried = 0
 
 def correct(bestmove,position):
     if not ('bm' in position.ops) and not ('am' in position.ops):
@@ -79,7 +81,7 @@ def process_info(info,results):
 
 def init(engine,options):
     # note: multipv not set here
-    engine.configure({'Hash': options.hash_size, 'Threads': options.cores})
+    engine.configure({'Hash': options.hash_size, 'Syzygypath': options.syzygy, 'Threads': options.cores})
     print("engine ready")
 
 def main(argv = None):
@@ -87,6 +89,7 @@ def main(argv = None):
     global results
     global position
     global solved
+    global tried
 
     engine = None
 
@@ -218,14 +221,17 @@ def main(argv = None):
                if (pv != None):
                   results.bestmove = pv[0]
                if (results.bestmove != None):
+                  tried = tried + 1
                   if correct(results.bestmove,position):
-                     print("++ solved in " + str(results.solution_time/1000.0) + " seconds (" + str(results.solution_nodes) + " nodes)",flush=True)
                      solved = solved + 1
+                     print("++ solved in " + str(results.solution_time/1000.0) + " seconds (" + str(results.solution_nodes) + " nodes)")
+                     print("solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%", flush=True)
                   else:
-                     print("-- not solved", flush=True)
+                     print("-- not solved")
+                     print("solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%", flush=True)
     engine.quit()
     print()
-    print("solved: " + str(solved))
+    print("RUN COMPLETED - solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%")
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -58,7 +58,6 @@ def process_info(info,results):
    try:
       result = results.infos[1]
    except KeyError:
-       print("no multiv")
        return
    if "time" in result:
       time = result["time"]
@@ -224,14 +223,17 @@ def main(argv = None):
                   tried = tried + 1
                   if correct(results.bestmove,position):
                      solved = solved + 1
-                     print("++ solved in " + str(results.solution_time/1000.0) + " seconds (" + str(results.solution_nodes) + " nodes)")
-                     print("solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%", flush=True)
+                     print("++ solved in " + str(results.solution_time/1000.0) + " seconds ("
+                            + str(results.solution_nodes)
+                            + " nodes)" + " (" + str(solved) + " out of " + str(tried) + " solved, "
+                            + str(round(solved * 100 /tried,1)) + "%)", flush=True)
+
                   else:
-                     print("-- not solved")
-                     print("solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%", flush=True)
+                     print("-- not solved" + " (" + str(solved) + " out of " + str(tried) + " solved, "
+                            + str(round(solved * 100 /tried,1)) + "%)", flush=True)
     engine.quit()
     print()
-    print("RUN COMPLETED - solved: " + str(solved) + " out of " + str(tried) + ";  " + str(round(solved * 100 /tried,1)) + "%")
+    print("RUN COMPLETED - " + str(solved) + " out of " + str(tried) + " solved (" + str(round(solved * 100 /tried,1)) + "%)")
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Modify analyze.py so that one runs using tee, e.g., 
```
'python analyze.py file.epd | tee file.txt',
```
 one can follow on the screen and view a running summary of the test.

Also add the ability to set syzygypath in analyze.py.
```
engine ready

8/8/3q3k/6pp/7P/3r2R1/5QPK/8 b - - bm g4; id "ACT3.001";

depth 22 seldepth 87 multipv 1 score +158 nodes 147663467 nps 9843574 hashfull 68 tbhits 713159 time 15.001 pv gxh4 Qf6+ Qxf6 Rxd3 Qf4+ Kg1 Qg4 Kh2 Kg5 Rh3 Qa4 Kg1 Qa1+ Kh2 Kf6 Rf3+ Kg6 Re3 Qd1 Rh3 Qe1 Rf3 Qe5+ Kh1 Qe6 Kh2 Qd6+ Kg1 Qc5+ Kh2 Qc7+ Kh1 Qc1+ Kh2 Kh6 Rd3 Qc7+ Kh1 Qb6 Rf3 Kg7
-- not solved
solved: 0 out of 1;  0.0%

4k1K1/2p1PR1n/2P2p1N/1P6/P7/1pb2nN1/r1b5/rqB4R w - - bm Re1; id "ACT3.002";

depth 43 seldepth 9 multipv 1 score #+5 nodes 124123447 nps 8274344 hashfull 997 tbhits 228 time 15.001 pv Re1 Nxe1 Ba3 Rxa3 Nhf5 Bxf5 Nh5 b2 Ng7#
++ solved in 0.58 seconds (5015210 nodes)
solved: 1 out of 2;  50.0%

6K1/8/1p6/p3Q2N/3p4/2r5/n5p1/1B1n1brk w - - bm Bd3; id "ACT3.003";

depth 25 seldepth 80 multipv 1 score +330 nodes 57915631 nps 3860784 hashfull 843 tbhits 951017 time 15.001 pv Bd3 Rxd3 Kf8 Rf3+ Ke7 Rf7+ Kd8 Rf8+ Kc7 Rf7+ Kxb6 Rb7+ Kxb7 Ba6+ Kxa6 Nb4+ Kb7 Rf1 Ng3+ Kg1 Qxd4+ Ne3 Qxe3+ Kh2 Ne2 g1=Q Qe5+ Kh3 Qh5+ Kg2 Nxg1 Rf2 Ne2 Rf3 Qxa5 Nd3 Qd5 Kf2 Nc3 Rh3 Ne4+ Ke3 Nc5 Nf2 Kb6 Rh1 Qe5+ Kf3
++ solved in 15.001 seconds (57915631 nodes)
solved: 2 out of 3;  66.7%
...
7k/pp6/2r2n2/4p1PN/1K2p1P1/1P1PP3/5PB1/8 b - - bm Nxh5; id "ACT3.100";

depth 30 seldepth 51 multipv 1 score 0 nodes 94001460 nps 6266346 hashfull 960 tbhits 556136 time 15.001 pv Nd5+ Ka3 exd3 Bxd5 d2 Bf3 e4 Be2 Rc1 g6 d1=R Bxd1 Rxd1 g7+ Kh7 Nf6+ Kxg7 Nxe4 Rg1 Nd6 Rxg4 Nxb7 Kf6 Na5 Ke6 f3 Rg8 Kb4 Kd5 Kb5 Rg7 Ka6 Kd6 b4 Kd5 b5 Rg3 e4+ Kc5 Nb7+ Kc4 Nd6+ Kc5 
-- not solved
solved: 52 out of 100;  52.0%

RUN COMPLETED - solved: 52 out of 100;  52.0%
```


