### PR TITLE
Fix compilation in C++20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/syzygy"]
 	path = src/syzygy
-	url = https://github.com/jdart1/Fathom
+	url = https://github.com/srogatch/Fathom.git
         ignore = dirty
 [submodule "tools/stats"]
 	path = tools/stats

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -24,6 +24,10 @@ static const score_t KING_COVER_RANGE = score_t(0.35*Params::PAWN_VALUE);
 static const score_t KING_ATTACK_COVER_BOOST_RANGE = Params::KING_ATTACK_FACTOR_RESOLUTION*30;
 
 // Non-const scoring parameters, modifiable by tuner
+// C++17 doesn't require out-of-header definitions
+// for const members, see https://en.cppreference.com/w/cpp/language/static
+// C++20 throws an error in such cases.
+#if __cplusplus < 202002L
 score_t Params::PAWN_VALUE_MIDGAME;
 score_t Params::PAWN_VALUE_ENDGAME;
 score_t Params::KNIGHT_VALUE_MIDGAME;
@@ -141,6 +145,7 @@ score_t Params::ROOK_MOBILITY[2][15];
 score_t Params::QUEEN_MOBILITY[2][24];
 score_t Params::KING_MOBILITY_ENDGAME[5];
 score_t Params::PAWN_STORM[2][4][5];
+#endif // __cplusplus
 
 int Tune::numTuningParams() const
 {


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/language/static :
In C++17:
"If a static data member is declared constexpr, it is implicitly inline and does not need to be redeclared at namespace scope. This redeclaration without an initializer (formerly required as shown above) is still permitted, but is deprecated."
In C++20, a noinline definition for such members (e.g., in a `.cpp` file) gives errors, at least in MSVC 2022.