### PR TITLE
Reduce strength mode: really use suboptimal() move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1463,6 +1463,9 @@ Move Search::ply0_search(std::vector<RootMove> *moveList)
            stats.best_line[1] = NullMove;
            Notation::image(board,best,
                            controller->uci ? Notation::OutputFormat::UCI : Notation::OutputFormat::SAN,stats.best_line_image);
+           if (mainThread()) {
+              controller->updateGlobalStats(stats);
+           }
       }
    }
    return node->best;


### PR DESCRIPTION
This propagates the move chosen by `suboptimal` so that the engine actually makes the move instead of ignoring it and picking the highest-ranked move. However, for the reduced strength mode to work well, a fix to `suboptimal` itself is also needed as it always chooses the move with the 4th-best evaluation regardless of level.