### PR TITLE
feat: add option to override opening book path

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ be specified, separated by ':'.
 Default is 1.
 - OwnBook - true or false. True to enable use of the Arasan book (book.bin)
 if installed. Default is true.
+- BookPath - path to the Arasan book. Default is book.bin in the same
+directory as the Arasan engine executable.
 - Favor frequent book moves - value from 0 to 100, default 50. Higher values
 favor selecting more frequent moves in the Arasan book.
 - Favor best book moves - value from 0 to 100, default 50. Higher values

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -224,8 +224,13 @@ void globals::delayedInit(bool verbose) {
 #endif
     // also initialize the book here
     if (options.book.book_enabled && !openingBook.is_open()) {
-        if (openingBook.open(derivePath(DEFAULT_BOOK_NAME).c_str()) && verbose) {
+        if (options.book.book_path == "") {
+            options.book.book_path = derivePath(DEFAULT_BOOK_NAME);
+        }
+        if (openingBook.open(options.book.book_path.c_str()) && verbose) {
             std::cout << debugPrefix << "warning: opening book not found or invalid" << std::endl;
+        } else if (verbose) {
+            std::cout << debugPrefix << "loaded opening book from file " << options.book.book_path << std::endl;
         }
     }
 }

--- a/src/options.h
+++ b/src/options.h
@@ -24,11 +24,13 @@ class Options
          weighting(100),
          scoring(50),
          random(50),
-         book_enabled(true)
+         book_enabled(true),
+         book_path("")
     { }
 
     unsigned frequency, weighting, scoring, random;
     bool book_enabled;
+    std::string book_path;
   } book;
 
   struct SearchOptions {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1802,6 +1802,7 @@ bool Protocol::do_command(const std::string &cmd, Board &board) {
 #endif
         std::cout << "option name MultiPV type spin default 1 min 1 max " << Statistics::MAX_PV << std::endl;
         std::cout << "option name OwnBook type check default " << (globals::options.book.book_enabled ? "true" : "false") << std::endl;
+        std::cout << "option name BookPath type string default " << (globals::options.book.book_path == "" ? "book.bin" : globals::options.book.book_path) << std::endl;
         std::cout << "option name Favor frequent book moves type spin default " <<
             globals::options.book.frequency << " min 0 max 100" << std::endl;
         std::cout << "option name Favor best book moves type spin default " <<
@@ -1901,6 +1902,9 @@ bool Protocol::do_command(const std::string &cmd, Board &board) {
 #endif
         else if (uciOptionCompare(name,"OwnBook")) {
             Options::setOption<bool>(value, globals::options.book.book_enabled);
+        }
+        else if (uciOptionCompare(name,"BookPath")) {
+            Options::setOption<std::string>(value,globals::options.book.book_path);
         }
         else if (uciOptionCompare(name,"Favor frequent book moves")) {
             Options::setOption<unsigned>(value,globals::options.book.frequency);


### PR DESCRIPTION
Hi Jon, great chess engine!  This PR adds an option (settable via UCI) to override the path to the opening book.  This is necessary when integrating Arasan into Apple platform apps (iOS, macOS, etc as part of a *.app, not a command line app) because  resources (e.g. book.bin) have to be included in the Resources folder within the application bundle, not at the location of the executable.

Let me know if you have any questions.