### PR TITLE
Fix NEON dpbusd NNUE accumulation

### DIFF
--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -955,7 +955,7 @@ void calcNnzData(const uint8_t *input, IndexType *nzIndices, size_t &nzCount) {
     // directly with an int32 compare and a movemask, then scatter their indices
     // using a precomputed table (no per-element scalar work).
     nzCount = 0;
-    constexpr size_t numGroups = inputSize / 4;
+    [[maybe_unused]] constexpr size_t numGroups = inputSize / 4;
 #if defined(NEON)
     // NEON has no direct movemask equivalent, so test groups of 4 bytes per lane.
     unsigned inputChunkSize = simdWidth / (8 * sizeof(int8_t));

--- a/src/nnue/simddefs.h
+++ b/src/nnue/simddefs.h
@@ -134,15 +134,24 @@ static inline int32_t hsum32(int32x4_t reg) {
 // must be templatized because shift must be a compile-time constant
 template<unsigned shift>
 static inline vec32_t vec_rshift32(vec32_t x) { return vshrq_n_s32(x, shift); }
-static inline vec32_t dpbusd_epi32(vec32_t sum, vec8_t a, vec8_t b) {
-#if defined(__aarch64__)
-    return vdotq_s32(sum, a, b);
+static inline void dpbusd_epi32(vec_t &sum, vec8_t a, vec8_t b) {
+    vec32_t sum32 = vreinterpretq_s32_s16(sum);
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+    sum32 = vusdotq_s32(sum32, vreinterpretq_u8_s8(a), b);
 #else
     // emulate x86 multipy-add instruction with NEON
-    int16x8_t prod_lo = vmull_s8(vget_low_s8(vreinterpretq_s8_u8(a)), vget_low_s8(b));
-    int16x8_t prod_hi = vmull_s8(vget_high_s8(vreinterpretq_s8_u8(a)), vget_high_s8(b));
-    return vaddq_s32(sum, vaddq_s32(vpaddlq_s16(prod_lo), vpaddlq_s16(prod_hi)));
+    uint8x16_t au = vreinterpretq_u8_s8(a);
+    int16x8_t a_lo = vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(au)));
+    int16x8_t a_hi = vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(au)));
+    int16x8_t b_lo = vmovl_s8(vget_low_s8(b));
+    int16x8_t b_hi = vmovl_s8(vget_high_s8(b));
+    int32x4_t pair_lo = vpaddlq_s16(vmulq_s16(a_lo, b_lo));
+    int32x4_t pair_hi = vpaddlq_s16(vmulq_s16(a_hi, b_hi));
+    int32x2_t group_lo = vpadd_s32(vget_low_s32(pair_lo), vget_high_s32(pair_lo));
+    int32x2_t group_hi = vpadd_s32(vget_low_s32(pair_hi), vget_high_s32(pair_hi));
+    sum32 = vaddq_s32(sum32, vcombine_s32(group_lo, group_hi));
 #endif
+    sum = vreinterpretq_s16_s32(sum32);
 }
 
 #else


### PR DESCRIPTION
## Summary

This fixes the NEON implementation of `dpbusd_epi32` used by the sparse NNUE path.

On Apple Silicon, `make BUILD_TYPE=neon unit` currently fails in the NNUE sparse linear tests:

```text
SparseLinear 1024x16 with byte size 1 failed.
SparseLinear 1792x16 with byte size 1 failed.
NNUE tests failed, skipping eval, search & perft tests
Unit tests ran: 24 error(s)
```

The NEON helper had two issues:

- It returned the updated accumulator instead of mutating the accumulator reference, unlike the x86 helpers and the existing call sites.
- It used signed-by-signed dot-product semantics, while `dpbusd` is unsigned-byte by signed-byte accumulation.

This patch updates the NEON helper to mutate the accumulator by reference and to preserve unsigned-by-signed semantics. It uses `vusdotq_s32` when the compiler target exposes `__ARM_FEATURE_MATMUL_INT8`, and otherwise uses a NEON fallback.

## Validation

Before this patch:

```text
SparseLinear 1024x16 with byte size 1 failed.
SparseLinear 1792x16 with byte size 1 failed.
NNUE tests failed, skipping eval, search & perft tests
Unit tests ran: 24 error(s)
```

After this patch, those `SparseLinear` failures are resolved.

On my Apple Silicon machine, the full unit target then reaches a separate eval-bound failure:

```text
testEval case 3 NNUE eval exceeds bounds: -12.44, expected [-12,-6]
Unit tests ran: 2 error(s)
```

I left that bound unchanged in this PR because it appears independent of the NEON `dpbusd` issue. A likely follow-up fix would be to relax that case's lower bound from `-12.0` to `-13.0`, since the current network evaluates the position at about `-12.44` on my Apple Silicon machine.

## Command Run

```sh
cd src
make clean
make BUILD_TYPE=neon unit
cp ../network/arasanv8-20260622.nnue ../bin/arasanv8-20260622.nnue
rm -rf ../bin/chess-openings
ln -s ../book/chess-openings ../bin/chess-openings
../bin/unit
```

## Note

Thanks for maintaining Arasan! I recently discovered it and am impressed. If you’d prefer this patch structured differently, or if there’s another validation path you’d like me to run, I’m happy to adjust.
