### PR TITLE
Clamp ply-adjusted mate scores before storing in hash

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -72,11 +72,11 @@ class HashEntry {
         if (score == Constants::INVALID_SCORE) {
             return score;
         } else if (score <= -Constants::MATE_RANGE) {
-            assert(score - (ply - 1) >= -Constants::MATE);
-            return score - (ply - 1);
+            score -= ply - 1;
+            return score < -Constants::MATE ? -Constants::MATE : score;
         } else if (score >= Constants::MATE_RANGE) {
-            assert(score + (ply - 1) <= Constants::MATE);
-            return score + (ply - 1);
+            score += ply - 1;
+            return score > Constants::MATE ? Constants::MATE : score;
         } else {
             return score;
         }


### PR DESCRIPTION
## Summary

This clamps ply-adjusted mate scores in `HashEntry::scoreToHashValue()` before storing them in the hash table.

In a debug build, I hit the existing assertion when a mate-range score was adjusted by `ply` and crossed `Constants::MATE` / `-Constants::MATE`. The adjustment itself looks intentional; the issue is that the adjusted value can rarely land just outside the asserted bound.

## Details

The previous code asserted that:

- negative mate scores stayed `>= -Constants::MATE` after subtracting `ply - 1`
- positive mate scores stayed `<= Constants::MATE` after adding `ply - 1`

This change keeps the same ply adjustment, but clamps the adjusted value to the mate bound before returning it.

This seems rare because it requires a mate-range score already close to the limit, combined with enough ply adjustment to push it just past the bound. That likely explains why it does not show up in ordinary engine use very often.

## Crash excerpt

The relevant debug crash excerpt was:

```text
Thread 7 Crashed:
0   libsystem_kernel.dylib              0x10015088c __pthread_kill + 8
1   libsystem_pthread.dylib             0x10047a338 pthread_kill + 264
2   libsystem_c.dylib                   0x18017b984 abort + 116
3   libsystem_c.dylib                   0x18017ad5c __assert_rtn + 268
4   SwiftChessDemo.debug.dylib          0x1065b21c0 HashEntry::scoreToHashValue(int, int) + 248 (hash.h:78)
5   SwiftChessDemo.debug.dylib          0x1065b1e44 Search::quiesce(int, int) + 5272 (search.cpp:2343)
6   SwiftChessDemo.debug.dylib          0x1065b0338 Search::quiesce(int, int, int, int) + 72 (search.h:185)
7   SwiftChessDemo.debug.dylib          0x1065b1278 Search::quiesce(int, int) + 2252 (search.cpp:2124)
8   SwiftChessDemo.debug.dylib          0x1065b0338 Search::quiesce(int, int, int, int) + 72 (search.h:185)
9   SwiftChessDemo.debug.dylib          0x1065b1c10 Search::quiesce(int, int) + 4708 (search.cpp:2296)
10  SwiftChessDemo.debug.dylib          0x1065b0338 Search::quiesce(int, int, int, int) + 72 (search.h:185)
11  SwiftChessDemo.debug.dylib          0x1065b1278 Search::quiesce(int, int) + 2252 (search.cpp:2124)
12  SwiftChessDemo.debug.dylib          0x1065b0338 Search::quiesce(int, int, int, int) + 72 (search.h:185)
13  SwiftChessDemo.debug.dylib          0x1065b1c10 Search::quiesce(int, int) + 4708 (search.cpp:2296)
14  SwiftChessDemo.debug.dylib          0x1065b0338 Search::quiesce(int, int, int, int) + 72 (search.h:185)
15  SwiftChessDemo.debug.dylib          0x1065b5288 Search::search() + 9192 (search.cpp:3250)
16  SwiftChessDemo.debug.dylib          0x1065b02d8 Search::search(int, int, int, int, int, int, unsigned long long) + 92 (search.h:176)
17  SwiftChessDemo.debug.dylib          0x1065b5244 Search::search() + 9124 (search.cpp:3246)
18  SwiftChessDemo.debug.dylib          0x1065b02d8 Search::search(int, int, int, int, int, int, unsigned long long) + 92 (search.h:176)
19  SwiftChessDemo.debug.dylib          0x1065af3ec Search::ply0_search(RootMoveGenerator&, int, int, int, int, std::__1::unordered_set<unsigned long long, MoveHash, MoveCmp, std::__1::allocator<unsigned long long>> const&) + 1524 (search.cpp:1614)
20  SwiftChessDemo.debug.dylib          0x1065a9908 Search::ply0_search(std::__1::vector<RootMoveGenerator::RootMove, std::__1::allocator<RootMoveGenerator::RootMove>>*) + 1620 (search.cpp:1254)
21  SwiftChessDemo.debug.dylib          0x1065a8254 SearchController::findBestMove(Board const&, SearchType, int, int, int, bool, bool, Statistics&, TalkLevel, std::__1::unordered_set<unsigned long long, MoveHash, MoveCmp, std::__1::allocator<unsigned long long>> const&, std::__1::unordered_set<unsigned long long, MoveHash, MoveCmp, std::__1::allocator<unsigned long long>> const&, std::__1::vector<RootMoveGenerator::RootMove, std::__1::allocator<RootMoveGenerator::RootMove>>*) + 2940 (search.cpp:543)
22  SwiftChessDemo.debug.dylib          0x106599630 Protocol::search(Board&, std::__1::unordered_set<unsigned long long, MoveHash, MoveCmp, std::__1::allocator<unsigned long long>> const&, Statistics&, bool) + 836 (protocol.cpp:1047)
23  SwiftChessDemo.debug.dylib          0x106592338 Protocol::do_command(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, Board&) + 20312 (protocol.cpp:2339)
24  SwiftChessDemo.debug.dylib          0x10658bd30 Protocol::do_all_pending(Board&) + 440 (protocol.cpp:206)
25  SwiftChessDemo.debug.dylib          0x10658ba84 Protocol::poll(bool&) + 60 (protocol.cpp:158)
26  SwiftChessDemo.debug.dylib          0x106509ce8 ArasanEmbedded::RunUCI(std::__1::basic_istream<char, std::__1::char_traits<char>>&, std::__1::basic_ostream<char, std::__1::char_traits<char>>&) + 308 (ArasanEmbeddedUCI.cpp:62)
27  SwiftChessDemo.debug.dylib          0x10650288c -[AEEngine runEngineLoop] + 288 (AEEngine.mm:271)
28  SwiftChessDemo.debug.dylib          0x106508370 -[AEEngine startEngine]::$_1::operator()() const + 56 (AEEngine.mm:211)
29  SwiftChessDemo.debug.dylib          0x106508304 std::__1::__invoke_result_impl<void, -[AEEngine startEngine]::$_1>::type std::__1::__invoke[abi:dee210106]<-[AEEngine startEngine]::$_1>(-[AEEngine startEngine]::$_1&&) + 24 (invoke.h:87)
30  SwiftChessDemo.debug.dylib          0x106508254 void std::__1::__thread_execute[abi:dee210106]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, -[AEEngine startEngine]::$_1>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, -[AEEngine startEngine]::$_1>&, std::__1::__tuple_indices<>) + 28 (thread.h:159)
31  SwiftChessDemo.debug.dylib          0x106507e60 void* std::__1::__thread_proxy[abi:dee210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, -[AEEngine startEngine]::$_1>>(void*) + 84 (thread.h:168)
32  libsystem_pthread.dylib             0x10047a63c _pthread_start + 104
33  libsystem_pthread.dylib             0x100475a34 thread_start + 8
```

Happy to adjust the approach if you would prefer this handled differently.

Thanks again for maintaining Arasan.
